### PR TITLE
Add timeout to flush buffers periodically

### DIFF
--- a/OpenEphys.Onix1/FrameWriter/ArrowBatchWriter.cs
+++ b/OpenEphys.Onix1/FrameWriter/ArrowBatchWriter.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading;
 using Apache.Arrow;
 
 namespace OpenEphys.Onix1.FrameWriter
@@ -11,9 +12,18 @@ namespace OpenEphys.Onix1.FrameWriter
     public class ArrowBatchWriter<T> : ArrowWriter
     {
         readonly int bufferSize;
-        readonly List<T> buffer;
         readonly Func<IList<T>, Schema, RecordBatch> createRecordBatch;
         readonly Schema schema;
+
+        List<T> buffer;
+
+        readonly Timer timer;
+        readonly object bufferLock = new();
+        readonly TimeSpan timeout;
+
+        int flushInProgress = 0;
+
+        volatile bool disposed = false;
 
         /// <summary>
         /// Initializes a new instance of the ArrowBatchWriter class with the specified output file, schema, buffer
@@ -22,14 +32,28 @@ namespace OpenEphys.Onix1.FrameWriter
         /// <param name="filename">The path to the output file.</param>
         /// <param name="schema">The schema describing the structure of the data.</param>
         /// <param name="bufferSize">The maximum number of items to buffer before writing a batch.</param>
+        /// <param name="timeout">The maximum time to wait before writing a batch.</param>
         /// <param name="createRecordBatch">A delegate to create a RecordBatch from a list of items and a schema.</param>
-        public ArrowBatchWriter(string filename, Schema schema, int bufferSize, Func<IList<T>, Schema, RecordBatch> createRecordBatch)
+        public ArrowBatchWriter(string filename, Schema schema, int bufferSize, TimeSpan timeout, Func<IList<T>, Schema, RecordBatch> createRecordBatch)
             : base(filename, schema)
         {
             this.schema = schema;
             this.bufferSize = bufferSize;
             buffer = new(bufferSize);
             this.createRecordBatch = createRecordBatch;
+            this.timeout = timeout;
+
+            timer = new Timer(
+                callback: TimerCallback,
+                state: null,
+                dueTime: Timeout.Infinite,
+                period: Timeout.Infinite);
+        }
+
+        void TimerCallback(object state)
+        {
+            if (disposed) return;
+            Flush();
         }
 
         /// <summary>
@@ -38,9 +62,23 @@ namespace OpenEphys.Onix1.FrameWriter
         /// <param name="item">The item to add to the buffer.</param>
         public void Write(T item)
         {
-            buffer.Add(item);
+            if (disposed) return;
 
-            if (buffer.Count >= bufferSize)
+            bool shouldFlush = false;
+
+            lock (bufferLock)
+            {
+                buffer.Add(item);
+
+                if (buffer.Count >= bufferSize)
+                {
+                    shouldFlush = true;
+                }
+
+                timer.Change(timeout, Timeout.InfiniteTimeSpan);
+            }
+
+            if (shouldFlush)
             {
                 Flush();
             }
@@ -51,11 +89,27 @@ namespace OpenEphys.Onix1.FrameWriter
         /// </summary>
         public void Flush()
         {
-            if (buffer.Count > 0)
+            if (Interlocked.CompareExchange(ref flushInProgress, 1, 0) != 0)
+                return;
+
+            try
             {
-                var recordBatch = createRecordBatch(buffer, schema);
+                List<T> snapshot;
+
+                lock (bufferLock)
+                {
+                    if (buffer.Count == 0) return;
+
+                    snapshot = buffer;
+                    buffer = new List<T>(bufferSize);
+                }
+
+                var recordBatch = createRecordBatch(snapshot, schema);
                 base.Write(recordBatch);
-                buffer.Clear();
+            }
+            finally
+            {
+                Interlocked.Exchange(ref flushInProgress, 0);
             }
         }
 
@@ -66,8 +120,11 @@ namespace OpenEphys.Onix1.FrameWriter
         {
             if (!disposed)
             {
+                timer.Dispose();
                 Flush();
                 base.Dispose();
+
+                disposed = true;
             }
         }
     }

--- a/OpenEphys.Onix1/FrameWriter/ArrowBatchWriter.cs
+++ b/OpenEphys.Onix1/FrameWriter/ArrowBatchWriter.cs
@@ -46,7 +46,7 @@ namespace OpenEphys.Onix1.FrameWriter
             timer = new Timer(
                 callback: TimerCallback,
                 state: null,
-                dueTime: Timeout.Infinite,
+                dueTime: timeout.Milliseconds,
                 period: Timeout.Infinite);
         }
 
@@ -74,8 +74,6 @@ namespace OpenEphys.Onix1.FrameWriter
                 {
                     shouldFlush = true;
                 }
-
-                timer.Change(timeout, Timeout.InfiniteTimeSpan);
             }
 
             if (shouldFlush)
@@ -91,6 +89,8 @@ namespace OpenEphys.Onix1.FrameWriter
         {
             if (Interlocked.CompareExchange(ref flushInProgress, 1, 0) != 0)
                 return;
+
+            timer.Change(timeout, Timeout.InfiniteTimeSpan);
 
             try
             {

--- a/OpenEphys.Onix1/FrameWriter/ArrowWriter.cs
+++ b/OpenEphys.Onix1/FrameWriter/ArrowWriter.cs
@@ -13,7 +13,7 @@ namespace OpenEphys.Onix1.FrameWriter
         readonly Stream stream = null;
         readonly ArrowFileWriter writer = null;
 
-        private protected bool disposed = false;
+        bool disposed = false;
 
         /// <summary>
         /// Initializes a new instance of the ArrowWriter class using the specified stream.

--- a/OpenEphys.Onix1/FrameWriter/FrameWriter.cs
+++ b/OpenEphys.Onix1/FrameWriter/FrameWriter.cs
@@ -90,6 +90,7 @@ namespace OpenEphys.Onix1.FrameWriter
             readonly Schema schema;
             readonly Func<IList<DataFrame>, Schema, RecordBatch> createRecordBatch;
             readonly int bufferSize;
+            readonly TimeSpan timeout;
 
             public DataFrameSink(
                 Schema schema,
@@ -99,11 +100,12 @@ namespace OpenEphys.Onix1.FrameWriter
                 this.schema = schema;
                 this.createRecordBatch = createRecordBatch;
                 this.bufferSize = bufferSize;
+                timeout = TimeSpan.FromSeconds(1);
             }
 
             protected override ArrowBatchWriter<DataFrame> CreateWriter(string filename, DataFrame frame)
             {
-                return new ArrowBatchWriter<DataFrame>(filename, schema, bufferSize, createRecordBatch);
+                return new ArrowBatchWriter<DataFrame>(filename, schema, bufferSize, timeout, createRecordBatch);
             }
 
             protected override void Write(ArrowBatchWriter<DataFrame> writer, DataFrame input)


### PR DESCRIPTION
This PR is to add a timeout that periodically flushes data. 

The timer is reset every time the `Flush` method is called; this should prevent it from firing immediately after a buffer fills up from repeated calls to `Write`, while also ensuring that the timeout is actually hit during slower periods of data collection. Previously I had it resetting when a new frame came in, but that could lead to a scenario where something like `DigitalIO` sends a sample right before the timeout fires, very slowly building the buffer. This could cause a loss of data depending on what the buffer size is.