### PR TITLE
Add expected sample rate attribute example

### DIFF
--- a/OpenEphys.Onix1/Bno055DataFrame.cs
+++ b/OpenEphys.Onix1/Bno055DataFrame.cs
@@ -21,6 +21,7 @@ namespace OpenEphys.Onix1
     /// and Roll = 0 degrees; Gravity: X = 0, Y = 0, Z = 9.8 m/s^2). Linear acceleration readings are always
     /// taken relative to the chip's axis definitions (they are "egocentric").
     /// </remarks>
+    [ExpectedSampleRate(100)]
     public class Bno055DataFrame : DataFrame
     {
         /// <summary>

--- a/OpenEphys.Onix1/ExpectedSampleRateAttribute.cs
+++ b/OpenEphys.Onix1/ExpectedSampleRateAttribute.cs
@@ -1,0 +1,25 @@
+﻿using System;
+
+namespace OpenEphys.Onix1
+{
+    /// <summary>
+    /// Specifies the expected sample rate for a data frame.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+    public sealed class ExpectedSampleRateAttribute : Attribute
+    {
+        /// <summary>
+        /// Gets the expected sample rate in hertz.
+        /// </summary>
+        public double SampleRateHz { get; private set; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ExpectedSampleRateAttribute"/> class with the specified sample rate in hertz.
+        /// </summary>
+        /// <param name="sampleRateHz">The expected sample rate in hertz.</param>
+        public ExpectedSampleRateAttribute(double sampleRateHz)
+        {
+            SampleRateHz = sampleRateHz;
+        }
+    }
+}

--- a/OpenEphys.Onix1/FrameWriter/FrameWriter.cs
+++ b/OpenEphys.Onix1/FrameWriter/FrameWriter.cs
@@ -171,21 +171,29 @@ namespace OpenEphys.Onix1.FrameWriter
         /// </returns>
         public IObservable<DataFrame> Process(IObservable<DataFrame> source)
         {
-            const int BufferSize = 50;
+
+            const int DefaultBufferSize = 50;
             Schema schema = null;
             Func<IList<DataFrame>, Schema, RecordBatch> createRecordBatch = null;
+            int bufferSize = DefaultBufferSize;
 
             return source.Replay(frames => Observable.Concat(
                 frames.Take(1)
                     .Do(frame =>
                     {
                         var frameType = frame.GetType();
+                        var sampleRateAttribute = frameType.GetCustomAttribute<ExpectedSampleRateAttribute>();
+                        if (sampleRateAttribute != null)
+                        {
+                            const double BufferDurationSeconds = 1.0;
+                            bufferSize = (int)(sampleRateAttribute.SampleRateHz * BufferDurationSeconds);
+                        }
                         var members = FrameWriterHelper.GetDataMembers(frameType);
                         schema = GenerateSchema(members, frame);
                         createRecordBatch = CreateDataFrameRecordBatchBuilder(frameType, members).Compile();
                     })
                     .IgnoreElements(),
-                Observable.Defer(() => CreateDataFrameSink(schema, createRecordBatch, BufferSize).Process(frames))
+                Observable.Defer(() => CreateDataFrameSink(schema, createRecordBatch, bufferSize).Process(frames))
             ), 1);
         }
     }

--- a/OpenEphys.Onix1/FrameWriter/FrameWriter.cs
+++ b/OpenEphys.Onix1/FrameWriter/FrameWriter.cs
@@ -18,6 +18,8 @@ namespace OpenEphys.Onix1.FrameWriter
     [WorkflowElementCategory(ElementCategory.Sink)]
     public class FrameWriter : FileSink
     {
+        const int DefaultBufferSize = 1000;
+
         BufferedDataFrameSink CreateBufferedDataFrameSink()
         {
             return new BufferedDataFrameSink
@@ -171,8 +173,6 @@ namespace OpenEphys.Onix1.FrameWriter
         /// </returns>
         public IObservable<DataFrame> Process(IObservable<DataFrame> source)
         {
-
-            const int DefaultBufferSize = 50;
             Schema schema = null;
             Func<IList<DataFrame>, Schema, RecordBatch> createRecordBatch = null;
             int bufferSize = DefaultBufferSize;

--- a/OpenEphys.Onix1/FrameWriter/FrameWriter.cs
+++ b/OpenEphys.Onix1/FrameWriter/FrameWriter.cs
@@ -133,6 +133,18 @@ namespace OpenEphys.Onix1.FrameWriter
                 members);
         }
 
+        static int GetBufferSize(Type frameType)
+        {
+            var sampleRateAttribute = frameType.GetCustomAttribute<ExpectedSampleRateAttribute>();
+            if (sampleRateAttribute != null)
+            {
+                const double BufferDurationSeconds = 1.0;
+                return (int)(sampleRateAttribute.SampleRateHz * BufferDurationSeconds);
+            }
+
+            return DefaultBufferSize;
+        }
+
         /// <summary>
         /// Writes all of the data frames in the sequence to an Apache Arrow file.
         /// </summary>
@@ -145,6 +157,7 @@ namespace OpenEphys.Onix1.FrameWriter
         {
             Schema schema = null;
             Func<BufferedDataFrame, Schema, RecordBatch> createRecordBatch = null;
+            int bufferSize = DefaultBufferSize;
 
             return source.Replay(frames => Observable.Concat(
                 frames.Take(1)
@@ -152,6 +165,7 @@ namespace OpenEphys.Onix1.FrameWriter
                     {
                         var frameType = frame.GetType();
                         var members = FrameWriterHelper.GetDataMembers(frameType);
+                        bufferSize = (int)Math.Ceiling((double)GetBufferSize(frameType) / frame.Clock.Length);
                         schema = GenerateSchema(members, frame);
                         createRecordBatch = CreateBufferedFrameRecordBatchBuilder(frameType, members).Compile();
                     })
@@ -182,13 +196,8 @@ namespace OpenEphys.Onix1.FrameWriter
                     .Do(frame =>
                     {
                         var frameType = frame.GetType();
-                        var sampleRateAttribute = frameType.GetCustomAttribute<ExpectedSampleRateAttribute>();
-                        if (sampleRateAttribute != null)
-                        {
-                            const double BufferDurationSeconds = 1.0;
-                            bufferSize = (int)(sampleRateAttribute.SampleRateHz * BufferDurationSeconds);
-                        }
                         var members = FrameWriterHelper.GetDataMembers(frameType);
+                        bufferSize = GetBufferSize(frameType);
                         schema = GenerateSchema(members, frame);
                         createRecordBatch = CreateDataFrameRecordBatchBuilder(frameType, members).Compile();
                     })


### PR DESCRIPTION
In preparation for issue [619](https://github.com/open-ephys/bonsai-onix1/issues/619), this PR adds the ability for `DataFrame`'s to include the estimated sample rate as an attribute.

In the `FrameWriter`, I set the duration of the buffer to be 1 second; this can be modified as needed. The duration and the expected sample rate are used to calculate the buffer size.