### PR TITLE
Seal ArrowBatchWriter class

### DIFF
--- a/OpenEphys.Onix1/FrameWriter/ArrowBatchWriter.cs
+++ b/OpenEphys.Onix1/FrameWriter/ArrowBatchWriter.cs
@@ -8,7 +8,7 @@ namespace OpenEphys.Onix1.FrameWriter
     /// Provides buffered writing of items to an Arrow file, batching items before writing.
     /// </summary>
     /// <typeparam name="T">The type of items to be written and batched.</typeparam>
-    public class ArrowBatchWriter<T> : ArrowWriter
+    public sealed class ArrowBatchWriter<T> : ArrowWriter
     {
         readonly int bufferSize;
         readonly List<T> buffer;

--- a/OpenEphys.Onix1/FrameWriter/ArrowWriter.cs
+++ b/OpenEphys.Onix1/FrameWriter/ArrowWriter.cs
@@ -47,9 +47,9 @@ namespace OpenEphys.Onix1.FrameWriter
             {
                 if (disposing)
                 {
-                    writer?.WriteEnd();
-                    writer?.Dispose();
-                    stream?.Dispose();
+                    writer.WriteEnd();
+                    writer.Dispose();
+                    stream.Dispose();
                 }
             }
         }


### PR DESCRIPTION
We know that the usage of this class is single-threaded, and therefore does not require a thread-safe Dispose() method
The `writer`/`stream` variables will not be null if the class is constructed without exception, so a null guard is not necessary