### PR TITLE
Add buffering for BufferedDataFrame's

### DIFF
--- a/OpenEphys.Onix1/FrameWriter/BufferedDataFrameExpressionProvider.cs
+++ b/OpenEphys.Onix1/FrameWriter/BufferedDataFrameExpressionProvider.cs
@@ -15,24 +15,32 @@ namespace OpenEphys.Onix1.FrameWriter
 
         public BufferedDataFrameExpressionProvider()
         {
-            InputParameter = Expression.Parameter(typeof(BufferedDataFrame), "frame");
+            InputParameter = Expression.Parameter(typeof(IList<BufferedDataFrame>), "frame");
         }
 
         public Expression GetLengthExpression()
         {
-            return Expression.ArrayLength(
-                    Expression.Property(
-                        InputParameter,
-                        nameof(BufferedDataFrame.Clock)));
+            // NB: We assume that all frames in the batch have the same number of rows, so we can take the length of the first frame's clock array and multiply by the number of frames.
+            var firstFrame = Expression.Property(
+                InputParameter,
+                typeof(IList<BufferedDataFrame>).GetProperty("Item"),
+                Expression.Constant(0));
+            var clockArray = Expression.Property(firstFrame, nameof(BufferedDataFrame.Clock));
+            var clockArrayLength = Expression.ArrayLength(clockArray);
+            var numberOfFrames = Expression.Property(
+                    Expression.Convert(InputParameter, typeof(ICollection<BufferedDataFrame>)),
+                    nameof(ICollection<BufferedDataFrame>.Count));
+            return Expression.Multiply(clockArrayLength, numberOfFrames);
         }
 
         public List<Expression> GetArrayPopulationExpressions(
             ParameterExpression arrowArrays,
             ParameterExpression arrowArrayIndex,
-            Expression batchRows,
+            ParameterExpression batchRows,
             Type frameType,
             IEnumerable<MemberInfo> members)
         {
+            var frameParameter = Expression.Parameter(typeof(BufferedDataFrame), "df");
             List<Expression> expressions = new();
 
             var stack = new Stack<MemberNode>(members.Select(m => new MemberNode { Member = m }));
@@ -44,34 +52,37 @@ namespace OpenEphys.Onix1.FrameWriter
 
                 if (memberType.IsArray)
                 {
-                    var convertMethod = typeof(FrameWriterHelper)
-                        .GetMethod(nameof(FrameWriterHelper.ConvertArrayToArrowArray), BindingFlags.Static | BindingFlags.NonPublic)
-                        .MakeGenericMethod(memberType.GetElementType());
+                    var memberAccessor = FrameWriterHelper.CreateMemberAccess(
+                        Expression.Convert(frameParameter, frameType),
+                        current);
 
-                    var arrayProperty = Expression.Property(
-                        Expression.Convert(InputParameter, frameType),
-                        current.GetFullName());
-                    var arrayArrowType = Expression.Constant(FrameWriterHelper.GetArrowType(memberType.GetElementType()));
+                    var convertFrameMemberMethod = typeof(BufferedDataFrameExpressionProvider)
+                                .GetMethod(nameof(ConvertFrameMemberToArrowArray), BindingFlags.Static | BindingFlags.NonPublic)
+                                .MakeGenericMethod(memberType.GetElementType());
 
-                    var block = Expression.Block(
-                        Expression.Assign(
-                            Expression.ArrayAccess(arrowArrays, arrowArrayIndex),
-                            Expression.Call(
-                                convertMethod,
-                                arrayProperty,
-                                arrayArrowType,
-                                batchRows)),
-                        Expression.PostIncrementAssign(arrowArrayIndex));
-
-                    expressions.Add(block);
+                    expressions.Add(ConvertFrameMemberExpressionBuilder(
+                        memberType, frameParameter, arrowArrays, arrowArrayIndex,
+                        InputParameter, memberAccessor,
+                        convertFrameMemberMethod));
                 }
                 else if (memberType == typeof(Mat))
                 {
+                    var combineMatMethod = typeof(BufferedDataFrameExpressionProvider)
+                        .GetMethod(nameof(CombineMatObjects), BindingFlags.Static | BindingFlags.NonPublic);
+
+                    var combinedMat = Expression.Variable(typeof(Mat), "combinedMat");
+                    var combineMatCall = Expression.Call(
+                        combineMatMethod,
+                        InputParameter,
+                        Expression.Lambda<Func<BufferedDataFrame, Mat>>(
+                            FrameWriterHelper.CreateMemberAccess(
+                                Expression.Convert(frameParameter, frameType),
+                                current),
+                            frameParameter));
+
                     var convertMatRowMethod = typeof(BufferedDataFrameExpressionProvider)
                         .GetMethod(nameof(ConvertMatRowToArrowArray), BindingFlags.Static | BindingFlags.NonPublic);
 
-                    var matProperty = Expression.Property(
-                        Expression.Convert(InputParameter, frameType), current.GetFullName());
                     var matElementType = Expression.Variable(typeof(IArrowType), "matElementType");
                     var rowIndex = Expression.Variable(typeof(int), "rowIndex");
                     var breakLabel = Expression.Label("break");
@@ -81,7 +92,7 @@ namespace OpenEphys.Onix1.FrameWriter
                             Expression.ArrayAccess(arrowArrays, arrowArrayIndex),
                             Expression.Call(
                                 convertMatRowMethod,
-                                matProperty,
+                                combinedMat,
                                 rowIndex,
                                 matElementType,
                                 batchRows)),
@@ -99,19 +110,23 @@ namespace OpenEphys.Onix1.FrameWriter
                                     null,
                                     new[] { typeof(Depth) },
                                     null),
-                                Expression.Property(matProperty, nameof(Mat.Depth)))),
+                                Expression.Property(combinedMat, nameof(Mat.Depth)))),
                         Expression.Loop(
                             Expression.IfThenElse(
                                 Expression.LessThan(
                                     rowIndex,
-                                    Expression.Property(matProperty, nameof(Mat.Rows))),
+                                    Expression.Property(combinedMat, nameof(Mat.Rows))),
                                 Expression.Block(
                                     loopBody,
                                     Expression.PostIncrementAssign(rowIndex)),
                                 Expression.Break(breakLabel)),
                             breakLabel));
 
-                    expressions.Add(forLoop);
+                    expressions.Add(Expression.Block(
+                        new[] { combinedMat },
+                        Expression.Assign(combinedMat, combineMatCall),
+                        forLoop
+                    ));
                 }
                 else
                 {
@@ -121,6 +136,69 @@ namespace OpenEphys.Onix1.FrameWriter
             }
 
             return expressions;
+        }
+
+        static int GetTotalSamples(IList<BufferedDataFrame> frames)
+        {
+            if (frames.Count == 0)
+                return 0;
+            int samplesPerFrame = frames[0].Clock.Length;
+            return frames.Count * samplesPerFrame;
+        }
+
+        static IArrowArray ConvertFrameMemberToArrowArray<TMember>(IList<BufferedDataFrame> frames, Func<BufferedDataFrame, TMember[]> getter, IArrowType arrowType) where TMember : unmanaged
+        {
+            int length = GetTotalSamples(frames);
+
+            if (length == 0)
+                return ArrowArrayFactory.BuildArray(new ArrayData(arrowType, 0, 0, 0, new[] { ArrowBuffer.Empty, ArrowBuffer.Empty }, null, null));
+
+            int samplesPerFrame = frames[0].Clock.Length;
+            var array = new TMember[length];
+
+            for (int i = 0; i < frames.Count; i++)
+            {
+                var member = getter(frames[i]);
+
+                for (int j = 0; j < samplesPerFrame; j++)
+                {
+                    array[i * samplesPerFrame + j] = member[j];
+                }
+            }
+
+            return FrameWriterHelper.ConvertArrayToArrowArray(array, arrowType, length);
+        }
+
+        static Expression ConvertFrameMemberExpressionBuilder(
+            Type memberType,
+            ParameterExpression frameParameter,
+            ParameterExpression arrowArrays,
+            ParameterExpression arrowArrayIndex,
+            ParameterExpression frames,
+            Expression memberAccessor,
+            MethodInfo convertFrameMemberMethod)
+        {
+            var arrayArrowType = Expression.Constant(FrameWriterHelper.GetArrowType(memberType.GetElementType()));
+            var getter = Expression.Lambda(
+                            typeof(Func<,>).MakeGenericType(typeof(BufferedDataFrame), memberType),
+                            memberAccessor,
+                            frameParameter
+                        );
+
+            var block = Expression.Block(
+                Expression.Assign(
+                    Expression.ArrayAccess(arrowArrays, arrowArrayIndex),
+                    Expression.Call(
+                        convertFrameMemberMethod,
+                        frames,
+                        getter,
+                        arrayArrowType
+                    )
+                ),
+                Expression.PostIncrementAssign(arrowArrayIndex)
+            );
+
+            return block;
         }
 
         static ArrowBuffer CreateStrideValidityBitmap(int validCount, int totalCount, int stride)
@@ -149,6 +227,29 @@ namespace OpenEphys.Onix1.FrameWriter
                 *destPtr = *srcPtr++;
                 destPtr += stride;
             }
+        }
+
+        static Mat CombineMatObjects(IList<BufferedDataFrame> frames, Func<BufferedDataFrame, Mat> getter)
+        {
+            Mat first = getter(frames[0]);
+            int length = first.Cols * frames.Count;
+
+            Mat dest = new(first.Rows, length, first.Depth, first.Channels);
+
+            int samplesPerFrame = first.Cols;
+            int rows = first.Rows;
+            int offset = 0;
+
+            for (int i = 0; i < frames.Count; i++)
+            {
+                Mat src = getter(frames[i]);
+
+                using var destRect = dest.GetSubRect(new Rect(offset, 0, samplesPerFrame, rows));
+                CV.Copy(src, destRect);
+                offset += samplesPerFrame;
+            }
+
+            return dest;
         }
 
         static unsafe IArrowArray ConvertMatRowToArrowArray(Mat mat, int rowIndex, IArrowType elementType, int batchRows)

--- a/OpenEphys.Onix1/FrameWriter/BufferedDataFrameSink.cs
+++ b/OpenEphys.Onix1/FrameWriter/BufferedDataFrameSink.cs
@@ -1,24 +1,34 @@
 ﻿using System;
+using System.Collections.Generic;
 using Apache.Arrow;
 using Bonsai.IO;
 
 namespace OpenEphys.Onix1.FrameWriter
 {
-    class BufferedDataFrameSink : FileSink<RecordBatch, ArrowWriter>
+    class BufferedDataFrameSink : FileSink<BufferedDataFrame, ArrowBatchWriter<BufferedDataFrame>>
     {
-        protected override ArrowWriter CreateWriter(string filename, RecordBatch batch)
+        readonly Schema schema;
+        readonly Func<IList<BufferedDataFrame>, Schema, RecordBatch> createRecordBatch;
+        readonly int bufferSize;
+
+        public BufferedDataFrameSink(
+            Schema schema,
+            Func<IList<BufferedDataFrame>, Schema, RecordBatch> createRecordBatch,
+            int bufferSize)
         {
-            return new ArrowWriter(filename, batch.Schema);
+            this.schema = schema;
+            this.createRecordBatch = createRecordBatch;
+            this.bufferSize = bufferSize;
         }
 
-        protected override void Write(ArrowWriter writer, RecordBatch input)
+        protected override ArrowBatchWriter<BufferedDataFrame> CreateWriter(string filename, BufferedDataFrame dataFrame)
+        {
+            return new ArrowBatchWriter<BufferedDataFrame>(filename, schema, bufferSize, createRecordBatch);
+        }
+
+        protected override void Write(ArrowBatchWriter<BufferedDataFrame> writer, BufferedDataFrame input)
         {
             writer.Write(input);
-        }
-
-        public IObservable<BufferedDataFrame> Process(IObservable<BufferedDataFrame> source, Func<BufferedDataFrame, RecordBatch> selector)
-        {
-            return base.Process(source, selector);
         }
     }
 }

--- a/OpenEphys.Onix1/FrameWriter/DataFrameExpressionProvider.cs
+++ b/OpenEphys.Onix1/FrameWriter/DataFrameExpressionProvider.cs
@@ -27,7 +27,7 @@ namespace OpenEphys.Onix1.FrameWriter
         public List<Expression> GetArrayPopulationExpressions(
             ParameterExpression arrowArrays,
             ParameterExpression arrowArrayIndex,
-            Expression batchRows,
+            ParameterExpression batchRows,
             Type frameType,
             IEnumerable<MemberInfo> members)
         {
@@ -43,18 +43,18 @@ namespace OpenEphys.Onix1.FrameWriter
 
                 if (memberType.IsPrimitive)
                 {
-                    var memberAccessor = CreateMemberAccess(
+                    var memberAccessor = FrameWriterHelper.CreateMemberAccess(
                         Expression.Convert(frameParameter, frameType),
                         current);
 
                     expressions.Add(ConvertFrameMemberExpressionBuilder(
                         memberType, frameParameter, arrowArrays, arrowArrayIndex,
-                        InputParameter, (MemberExpression)batchRows, memberAccessor));
+                        InputParameter, batchRows, memberAccessor));
                 }
                 else if (memberType.IsEnum)
                 {
                     var memberAccessor = Expression.Convert(
-                        CreateMemberAccess(
+                        FrameWriterHelper.CreateMemberAccess(
                             Expression.Convert(frameParameter, frameType),
                             current),
                         Enum.GetUnderlyingType(memberType));
@@ -62,7 +62,7 @@ namespace OpenEphys.Onix1.FrameWriter
                     expressions.Add(ConvertFrameMemberExpressionBuilder(
                         Enum.GetUnderlyingType(memberType), frameParameter,
                         arrowArrays, arrowArrayIndex, InputParameter,
-                        (MemberExpression)batchRows, memberAccessor));
+                        batchRows, memberAccessor));
                 }
                 else if (memberType.IsValueType)
                 {
@@ -90,21 +90,6 @@ namespace OpenEphys.Onix1.FrameWriter
             return expressions;
         }
 
-        static MemberExpression CreateMemberAccess(Expression instance, MemberInfo member)
-        {
-            return member is PropertyInfo property
-                ? Expression.Property(instance, property)
-                : Expression.Field(instance, (FieldInfo)member);
-        }
-
-        static MemberExpression CreateMemberAccess(Expression instance, MemberNode member)
-        {
-            if (member.Parent == null)
-                return CreateMemberAccess(instance, member.Member);
-
-            return CreateMemberAccess(CreateMemberAccess(instance, member.Parent), member.Member);
-        }
-
         static IArrowArray ConvertFrameMemberToArrowArray<TMember>(IList<DataFrame> frames, Func<DataFrame, TMember> getter, IArrowType arrowType, int length) where TMember : unmanaged
         {
             var array = new TMember[length];
@@ -123,7 +108,7 @@ namespace OpenEphys.Onix1.FrameWriter
             ParameterExpression arrowArrays,
             ParameterExpression arrowArrayIndex,
             ParameterExpression frames,
-            MemberExpression count,
+            ParameterExpression count,
             Expression memberAccessor)
         {
             var convertFrameMemberMethod = typeof(DataFrameExpressionProvider)
@@ -135,7 +120,7 @@ namespace OpenEphys.Onix1.FrameWriter
                             typeof(Func<,>).MakeGenericType(typeof(DataFrame), memberType),
                             memberAccessor,
                             frameParameter
-                        ).Compile();
+                        );
 
             var block = Expression.Block(
                 Expression.Assign(
@@ -143,7 +128,7 @@ namespace OpenEphys.Onix1.FrameWriter
                     Expression.Call(
                         convertFrameMemberMethod,
                         frames,
-                        Expression.Constant(getter, getter.GetType()),
+                        getter,
                         arrayArrowType,
                         count
                     )

--- a/OpenEphys.Onix1/FrameWriter/FrameWriter.cs
+++ b/OpenEphys.Onix1/FrameWriter/FrameWriter.cs
@@ -18,9 +18,12 @@ namespace OpenEphys.Onix1.FrameWriter
     [WorkflowElementCategory(ElementCategory.Sink)]
     public class FrameWriter : FileSink
     {
-        BufferedDataFrameSink CreateBufferedDataFrameSink()
+        BufferedDataFrameSink CreateBufferedDataFrameSink(
+            Schema schema,
+            Func<IList<BufferedDataFrame>, Schema, RecordBatch> createRecordBatch,
+            int bufferSize)
         {
-            return new BufferedDataFrameSink
+            return new BufferedDataFrameSink(schema, createRecordBatch, bufferSize)
             {
                 FileName = this.FileName,
                 Suffix = this.Suffix,
@@ -121,11 +124,11 @@ namespace OpenEphys.Onix1.FrameWriter
                 members);
         }
 
-        static Expression<Func<BufferedDataFrame, Schema, RecordBatch>> CreateBufferedFrameRecordBatchBuilder(
+        static Expression<Func<IList<BufferedDataFrame>, Schema, RecordBatch>> CreateBufferedFrameRecordBatchBuilder(
             Type frameType,
             IEnumerable<MemberInfo> members)
         {
-            return RecordBatchExpressionFactory.CreateBuilder<Func<BufferedDataFrame, Schema, RecordBatch>>(
+            return RecordBatchExpressionFactory.CreateBuilder<Func<IList<BufferedDataFrame>, Schema, RecordBatch>>(
                 new BufferedDataFrameExpressionProvider(),
                 frameType,
                 members);
@@ -141,8 +144,10 @@ namespace OpenEphys.Onix1.FrameWriter
         /// </returns>
         public IObservable<BufferedDataFrame> Process(IObservable<BufferedDataFrame> source)
         {
+            const int BufferSizeInSamples = 30000;
             Schema schema = null;
-            Func<BufferedDataFrame, Schema, RecordBatch> createRecordBatch = null;
+            Func<IList<BufferedDataFrame>, Schema, RecordBatch> createRecordBatch = null;
+            int bufferSize = 1000;
 
             return source.Replay(frames => Observable.Concat(
                 frames.Take(1)
@@ -150,14 +155,12 @@ namespace OpenEphys.Onix1.FrameWriter
                     {
                         var frameType = frame.GetType();
                         var members = FrameWriterHelper.GetDataMembers(frameType);
+                        bufferSize = (int)Math.Ceiling((double)BufferSizeInSamples / frame.Clock.Length);
                         schema = GenerateSchema(members, frame);
                         createRecordBatch = CreateBufferedFrameRecordBatchBuilder(frameType, members).Compile();
                     })
                     .IgnoreElements(),
-                Observable.Defer(() => CreateBufferedDataFrameSink().Process(
-                    frames,
-                    frame => createRecordBatch(frame, schema)
-                ))
+                Observable.Defer(() => CreateBufferedDataFrameSink(schema, createRecordBatch, bufferSize).Process(frames))
             ), 1);
         }
 

--- a/OpenEphys.Onix1/FrameWriter/FrameWriterHelper.cs
+++ b/OpenEphys.Onix1/FrameWriter/FrameWriterHelper.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Linq.Expressions;
 using System.Reflection;
 using Apache.Arrow;
 using Apache.Arrow.Types;
@@ -43,6 +44,21 @@ namespace OpenEphys.Onix1.FrameWriter
             );
 
             return ArrowArrayFactory.BuildArray(arrayData);
+        }
+
+        static MemberExpression CreateMemberAccess(Expression instance, MemberInfo member)
+        {
+            return member is PropertyInfo property
+                ? Expression.Property(instance, property)
+                : Expression.Field(instance, (FieldInfo)member);
+        }
+
+        internal static MemberExpression CreateMemberAccess(Expression instance, MemberNode member)
+        {
+            if (member.Parent == null)
+                return CreateMemberAccess(instance, member.Member);
+
+            return CreateMemberAccess(CreateMemberAccess(instance, member.Parent), member.Member);
         }
 
         internal static IArrowType GetArrowType(Type type) => ArrowTypeMap.TryGetValue(type, out var arrowType)

--- a/OpenEphys.Onix1/FrameWriter/IRecordBatchExpressionProvider.cs
+++ b/OpenEphys.Onix1/FrameWriter/IRecordBatchExpressionProvider.cs
@@ -14,7 +14,7 @@ namespace OpenEphys.Onix1.FrameWriter
         List<Expression> GetArrayPopulationExpressions(
             ParameterExpression arrowArrays,
             ParameterExpression arrowArrayIndex,
-            Expression batchRows,
+            ParameterExpression batchRows,
             Type frameType,
             IEnumerable<MemberInfo> members);
     }

--- a/OpenEphys.Onix1/FrameWriter/RecordBatchExpressionFactory.cs
+++ b/OpenEphys.Onix1/FrameWriter/RecordBatchExpressionFactory.cs
@@ -44,8 +44,13 @@ namespace OpenEphys.Onix1.FrameWriter
             var arrowArrayIndex = Expression.Variable(typeof(int), "arrowArrayIndex");
             var schemaParameter = Expression.Parameter(typeof(Schema), "schema");
             var batchRowsExpression = provider.GetLengthExpression();
+            var batchRowsVariable = Expression.Variable(typeof(int), "batchRows");
 
-            expressions.Add(batchRowsExpression);
+            parameters.Add(batchRowsVariable);
+            expressions.Add(Expression.Assign(
+                batchRowsVariable,
+                batchRowsExpression
+            ));
 
             parameters.Add(arrowArrays);
             expressions.Add(InitializeArrowArrayFromSchema(schemaParameter, arrowArrays));
@@ -55,13 +60,13 @@ namespace OpenEphys.Onix1.FrameWriter
 
             expressions.AddRange(
                 provider.GetArrayPopulationExpressions(
-                    arrowArrays, arrowArrayIndex, batchRowsExpression, frameType, members));
+                    arrowArrays, arrowArrayIndex, batchRowsVariable, frameType, members));
 
             var recordBatch = Expression.Variable(typeof(RecordBatch), "recordBatch");
             parameters.Add(recordBatch);
             expressions.Add(Expression.Assign(
                 recordBatch,
-                Expression.New(recordBatchConstructor, schemaParameter, arrowArrays, batchRowsExpression)));
+                Expression.New(recordBatchConstructor, schemaParameter, arrowArrays, batchRowsVariable)));
 
             var createRecordBatch = Expression.Block(parameters, expressions);
 


### PR DESCRIPTION
## Overview

Similar to how `DataFrame`'s are handled, all `BufferedDataFrame`'s are now buffered by creating a list of frames, and then combining all data into one `RecordBatch`

Due to Arrow constraints, we cannot perform zero-copy operations on the `Mat` properties now. We are using `OpenCV.Net` methods to copy once into a single `Mat` object, and then using the existing zero-copy operations to create Arrow arrays from the combined `Mat` object

`BufferedDataFrame`'s buffer 30,000 samples as the default value. This number can be changed depending on the expected sample rate when that functionality is added by #12 

## Performance
Tested using a buffer size of 30,000, and a frame size of 36. Collected 1 hour's worth of data for testing.

### Saving data
- Save Time: 4 min 20 seconds (260 s)
- Hot path: ArrowBatchWriter → Flush → CreateRecordBatch / WriteRecordBatchInternal (Apache.Arrow)
  - CreateRecordBatch accounts for 27.51% of CPU time
  - Calls to CV.Copy accounted for 26.93% of CPU time
  - WriteRecordBatchInternal accounts for 56.92% of CPU time

<img width="1295" height="311" alt="image" src="https://github.com/user-attachments/assets/e1f70844-46b4-48a3-89ef-87406f504539" />

- File Size: 156 GB
- Memory usage: Far fewer garbage collection events than previously seen, but higher memory usage.
  - Looking at the memory heap, due to the increased size of the objects when buffering the `BufferedDataFrame`'s, they are sent to the Large Object Heap (LOH) which is handled differently than other generations of objects. When acquisition is running, these are periodically collected, but once acquisition stops they can stick around even if they are considered "dead objects". 
- Metadata tracking (block size and offset) requires 160 bytes per block written. 3600 blocks were written for 1 hour of data, equating to 576 kB of data needed per node per hour of memory 

### Loading data
- On average, takes 71 seconds to load 1 hour of data
- Even with a 156 GB file, it does not overflow my 32 GB of RAM due to memory mapping the file correctly
- Random access within the file has an affect on time to load (seems to be slightly longer based on the estimated curve), but overall it is fairly performant here to load the data

<img width="1002" height="674" alt="image" src="https://github.com/user-attachments/assets/ef8a8998-3285-4d80-b5f2-ee57b3a8b809" />
