### PR TITLE
Add expected sample rate attribute

### DIFF
--- a/OpenEphys.Onix1/AnalogInputDataFrame.cs
+++ b/OpenEphys.Onix1/AnalogInputDataFrame.cs
@@ -6,6 +6,7 @@ namespace OpenEphys.Onix1
     /// <summary>
     /// Buffered analog data produced by the ONIX breakout board.
     /// </summary>
+    [ExpectedSampleRate(100_000)]
     public class AnalogInputDataFrame : BufferedDataFrame
     {
         /// <summary>

--- a/OpenEphys.Onix1/Bno055DataFrame.cs
+++ b/OpenEphys.Onix1/Bno055DataFrame.cs
@@ -21,6 +21,7 @@ namespace OpenEphys.Onix1
     /// and Roll = 0 degrees; Gravity: X = 0, Y = 0, Z = 9.8 m/s^2). Linear acceleration readings are always
     /// taken relative to the chip's axis definitions (they are "egocentric").
     /// </remarks>
+    [ExpectedSampleRate(100)]
     public class Bno055DataFrame : DataFrame
     {
         /// <summary>

--- a/OpenEphys.Onix1/ExpectedSampleRateAttribute.cs
+++ b/OpenEphys.Onix1/ExpectedSampleRateAttribute.cs
@@ -1,0 +1,25 @@
+﻿using System;
+
+namespace OpenEphys.Onix1
+{
+    /// <summary>
+    /// Specifies the expected sample rate for a data frame.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+    public sealed class ExpectedSampleRateAttribute : Attribute
+    {
+        /// <summary>
+        /// Gets the expected sample rate in hertz.
+        /// </summary>
+        public double SampleRateHz { get; private set; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ExpectedSampleRateAttribute"/> class with the specified sample rate in hertz.
+        /// </summary>
+        /// <param name="sampleRateHz">The expected sample rate in hertz.</param>
+        public ExpectedSampleRateAttribute(double sampleRateHz)
+        {
+            SampleRateHz = sampleRateHz;
+        }
+    }
+}

--- a/OpenEphys.Onix1/FrameWriter/FrameWriter.cs
+++ b/OpenEphys.Onix1/FrameWriter/FrameWriter.cs
@@ -19,6 +19,9 @@ namespace OpenEphys.Onix1.FrameWriter
     public class FrameWriter : FileSink
     {
         readonly TimeSpan BufferTimeout = TimeSpan.FromSeconds(5);
+        const int DefaultBufferSize = 1000;
+        const int MinimumBufferSize = 50;
+        const int MaximumBufferSize = 10000;
 
         BufferedDataFrameSink CreateBufferedDataFrameSink(
             Schema schema,
@@ -138,6 +141,21 @@ namespace OpenEphys.Onix1.FrameWriter
                 members);
         }
 
+        static int ClampBufferSize(int bufferSize) => Math.Min(Math.Max(bufferSize, MinimumBufferSize), MaximumBufferSize);
+
+        static int GetBufferSize(Type frameType)
+        {
+            var sampleRateAttribute = frameType.GetCustomAttribute<ExpectedSampleRateAttribute>();
+            if (sampleRateAttribute != null)
+            {
+                const double BufferDurationSeconds = 1.0;
+                int bufferSize = (int)(sampleRateAttribute.SampleRateHz * BufferDurationSeconds);
+                return ClampBufferSize(bufferSize);
+            }
+
+            return DefaultBufferSize;
+        }
+
         /// <summary>
         /// Writes all of the data frames in the sequence to an Apache Arrow file.
         /// </summary>
@@ -148,10 +166,9 @@ namespace OpenEphys.Onix1.FrameWriter
         /// </returns>
         public IObservable<BufferedDataFrame> Process(IObservable<BufferedDataFrame> source)
         {
-            const int BufferSizeInSamples = 30000;
             Schema schema = null;
             Func<IList<BufferedDataFrame>, Schema, RecordBatch> createRecordBatch = null;
-            int bufferSize = 1000;
+            int bufferSize = DefaultBufferSize;
 
             return source.Replay(frames => Observable.Concat(
                 frames.Take(1)
@@ -159,7 +176,7 @@ namespace OpenEphys.Onix1.FrameWriter
                     {
                         var frameType = frame.GetType();
                         var members = FrameWriterHelper.GetDataMembers(frameType);
-                        bufferSize = (int)Math.Ceiling((double)BufferSizeInSamples / frame.Clock.Length);
+                        bufferSize = (int)Math.Ceiling((double)GetBufferSize(frameType) / frame.Clock.Length);
                         schema = GenerateSchema(members, frame);
                         createRecordBatch = CreateBufferedFrameRecordBatchBuilder(frameType, members).Compile();
                     })
@@ -178,9 +195,9 @@ namespace OpenEphys.Onix1.FrameWriter
         /// </returns>
         public IObservable<DataFrame> Process(IObservable<DataFrame> source)
         {
-            const int BufferSize = 50;
             Schema schema = null;
             Func<IList<DataFrame>, Schema, RecordBatch> createRecordBatch = null;
+            int bufferSize = DefaultBufferSize;
 
             return source.Replay(frames => Observable.Concat(
                 frames.Take(1)
@@ -188,11 +205,12 @@ namespace OpenEphys.Onix1.FrameWriter
                     {
                         var frameType = frame.GetType();
                         var members = FrameWriterHelper.GetDataMembers(frameType);
+                        bufferSize = GetBufferSize(frameType);
                         schema = GenerateSchema(members, frame);
                         createRecordBatch = CreateDataFrameRecordBatchBuilder(frameType, members).Compile();
                     })
                     .IgnoreElements(),
-                Observable.Defer(() => CreateDataFrameSink(schema, createRecordBatch, BufferSize, BufferTimeout).Process(frames))
+                Observable.Defer(() => CreateDataFrameSink(schema, createRecordBatch, bufferSize, BufferTimeout).Process(frames))
             ), 1);
         }
     }

--- a/OpenEphys.Onix1/NeuropixelsV1DataFrame.cs
+++ b/OpenEphys.Onix1/NeuropixelsV1DataFrame.cs
@@ -5,6 +5,7 @@ namespace OpenEphys.Onix1
     /// <summary>
     /// Buffered data from a NeuropixelsV1 probe.
     /// </summary>
+    [ExpectedSampleRate(30_000)]
     public class NeuropixelsV1DataFrame : BufferedDataFrame
     {
         /// <summary>

--- a/OpenEphys.Onix1/NeuropixelsV2eBetaDataFrame.cs
+++ b/OpenEphys.Onix1/NeuropixelsV2eBetaDataFrame.cs
@@ -6,6 +6,7 @@ namespace OpenEphys.Onix1
     /// <summary>
     /// Buffered data from a NeuropixelsV2-Beta probe.
     /// </summary>
+    [ExpectedSampleRate(30_000)]
     public class NeuropixelsV2eBetaDataFrame : BufferedDataFrame
     {
         /// <summary>

--- a/OpenEphys.Onix1/NeuropixelsV2eDataFrame.cs
+++ b/OpenEphys.Onix1/NeuropixelsV2eDataFrame.cs
@@ -6,6 +6,7 @@ namespace OpenEphys.Onix1
     /// <summary>
     /// Buffered data from a NeuropixelsV2 probe.
     /// </summary>
+    [ExpectedSampleRate(30_000)]
     public class NeuropixelsV2eDataFrame : BufferedDataFrame
     {
         /// <summary>

--- a/OpenEphys.Onix1/Nric1384DataFrame.cs
+++ b/OpenEphys.Onix1/Nric1384DataFrame.cs
@@ -6,6 +6,7 @@ namespace OpenEphys.Onix1
     /// <summary>
     /// Buffered data from a Nric1384 bioacquisition chip.
     /// </summary>
+    [ExpectedSampleRate(30_000)]
     public class Nric1384DataFrame : BufferedDataFrame
     {
         /// <summary>

--- a/OpenEphys.Onix1/Rhd2164DataFrame.cs
+++ b/OpenEphys.Onix1/Rhd2164DataFrame.cs
@@ -6,6 +6,7 @@ namespace OpenEphys.Onix1
     /// <summary>
     /// Electrophysiology data produced by an Rhd2164 bioamplifier chip.
     /// </summary>
+    [ExpectedSampleRate(30_000)]
     public class Rhd2164DataFrame : BufferedDataFrame
     {
         /// <summary>

--- a/OpenEphys.Onix1/Rhs2116DataFrame.cs
+++ b/OpenEphys.Onix1/Rhs2116DataFrame.cs
@@ -10,6 +10,7 @@ namespace OpenEphys.Onix1
     /// <summary>
     /// Buffered data from a Rhs2116 device.
     /// </summary>
+    [ExpectedSampleRate(30_193)]
     public class Rhs2116DataFrame : BufferedDataFrame
     {
         /// <summary>

--- a/OpenEphys.Onix1/Rhs2116PairDataFrame.cs
+++ b/OpenEphys.Onix1/Rhs2116PairDataFrame.cs
@@ -5,6 +5,7 @@ namespace OpenEphys.Onix1
     /// <summary>
     /// Buffered data from two Rhs2116 devices.
     /// </summary>
+    [ExpectedSampleRate(30_193)]
     public class Rhs2116PairDataFrame : BufferedDataFrame
     {
         /// <summary>


### PR DESCRIPTION
In preparation for issue https://github.com/open-ephys/bonsai-onix1/issues/619, this PR adds the ability for DataFrame's to include the estimated sample rate as an attribute.

In the FrameWriter, I set the duration of the buffer to be 1 second; this can be modified as needed. The duration and the expected sample rate are used to calculate the buffer size.